### PR TITLE
Allow completion to specify that the suffix should be removed, fixes #5.

### DIFF
--- a/complete.js
+++ b/complete.js
@@ -327,7 +327,7 @@ define(function(require, exports, module) {
             
             tooltip.setLastCompletion(match, pos);
 
-            if (deleteSuffix || newText.slice(-postfix.length) === postfix)
+            if (deleteSuffix || newText.slice(-postfix.length) === postfix || match.deleteSuffix)
                 doc.removeInLine(pos.row, pos.column - prefix.length, pos.column + postfix.length);
             else
                 doc.removeInLine(pos.row, pos.column - prefix.length, pos.column);


### PR DESCRIPTION
For a completion like
{
  name: "dictionary",
  replaceText: "dictionary",
  deleteSuffix: true,
  meta: "Dictionary",
  priority: 100
}
taking that suggestion for digtio^nary will actually replace the
whole word.
